### PR TITLE
Fixed bad status response

### DIFF
--- a/src/StripePaymentType.php
+++ b/src/StripePaymentType.php
@@ -2,16 +2,15 @@
 
 namespace GetCandy\Stripe;
 
+use GetCandy\Base\DataTransferObjects\PaymentAuthorize;
 use GetCandy\Base\DataTransferObjects\PaymentCapture;
 use GetCandy\Base\DataTransferObjects\PaymentRefund;
-use GetCandy\Base\DataTransferObjects\PaymentAuthorize;
 use GetCandy\Models\Transaction;
 use GetCandy\PaymentTypes\AbstractPayment;
 use GetCandy\Stripe\Facades\StripeFacade;
 use Illuminate\Support\Facades\DB;
 use Stripe\Exception\InvalidRequestException;
 use Stripe\PaymentIntent;
-use Stripe\StripeClient;
 
 class StripePaymentType extends AbstractPayment
 {
@@ -91,8 +90,11 @@ class StripePaymentType extends AbstractPayment
             }
         }
 
-
-        if (!in_array($this->paymentIntent->status, ['success', 'processing', 'requires_capture'])) {
+        if (!in_array($this->paymentIntent->status, [
+            'processing',
+            'requires_capture',
+            'succeeded'
+        ])) {
             return new PaymentAuthorize(
                 success: false,
                 message: $this->paymentIntent->last_payment_error,

--- a/tests/Stripe/MockClient.php
+++ b/tests/Stripe/MockClient.php
@@ -26,7 +26,7 @@ class MockClient implements ClientInterface
             if (str_contains($absUrl, 'PI_CAPTURE')) {
                 $this->rBody = $this->getResponse('payment_intent_paid', [
                     'id' => $id,
-                    'status' => 'success',
+                    'status' => 'succeeded',
                     'payment_status' => 'succeeded',
                 ]);
                 return [$this->rBody, $this->rcode, $this->rheaders];


### PR DESCRIPTION
Stripe addon checks 'success' instead of 'succeeded' leading to a failed order even if it's paid. (https://stripe.com/docs/api/errors#errors-payment_intent-status)